### PR TITLE
2 minor fixes

### DIFF
--- a/liclient/__init__.py
+++ b/liclient/__init__.py
@@ -245,11 +245,11 @@ class LinkedInAPI(object):
     def append_initial_arg(self, key, args, prep_url):
         assert '?' not in prep_url, 'Initial argument has already been applied to %s' % prep_url
         if type(args) == type([]):
-            prep_url += '?' + key + '=' + str(args[0])
+            prep_url = prep_url[:-1] + key + '=' + str(args[0])
             if len(args) > 1:
                 prep_url += ''.join(['&' + key + '=' + str(arg) for arg in args[1:]])
         else:
-            prep_url += '?' + key + '=' + str(args)
+            prep_url = prep_url[:-1] + key + '=' + str(args)
         return prep_url
     
     def append_sequential_arg(self, key, args, prep_url):

--- a/liclient/__init__.py
+++ b/liclient/__init__.py
@@ -375,11 +375,10 @@ class LinkedInAPI(object):
 class LinkedInCompanySearchAPI(LinkedInAPI):
     def __init__(self, params, access_token, field_selector_string=None):
         self.api_search_url = 'http://api.linkedin.com/v1/companies'
-        if field_selector_string:
-            self.api_search_url += ':' + field_selector_string
-        self.api_search_url += '?'
+        self.field_selector_string = field_selector_string
         self.routing = {
             'email-domain': self.email_domain,
+            'universal-name': self.universal_domain,
         }
         self.user_token, self.generated_url = self.do_process(access_token, params)
         print "url:", self.generated_url
@@ -406,10 +405,23 @@ class LinkedInCompanySearchAPI(LinkedInAPI):
 
     def email_domain(self, url, val):
         prep_url = url
+        if self.field_selector_string:
+            prep_url += ':' + self.field_selector_string
+        prep_url += '?'
         try:
             prep_url = self.append_initial_arg('email-domain', val, prep_url)
         except AssertionError:
             prep_url = self.append_sequential_arg('email-domain', val, prep_url)
+        return prep_url
+
+    def universal_domain(self, url, val):
+        prep_url = url + '/'
+        try:
+            prep_url = self.append_initial_arg('universal-name', val, prep_url)
+        except AssertionError:
+            prep_url = self.append_sequential_arg('universal-name', val, prep_url)
+        if self.field_selector_string:
+            prep_url += ':' + self.field_selector_string
         return prep_url
 
 class LinkedInSearchAPI(LinkedInAPI):

--- a/liclient/__init__.py
+++ b/liclient/__init__.py
@@ -241,6 +241,7 @@ class LinkedInAPI(object):
                     prep_url = self.append_initial_arg(k, kws[k], prep_url)
                 else:
                     prep_url = self.append_sequential_arg(k, kws[k], prep_url)
+        if not kws: prep_url += '~'
         prep_url = re.sub('&&', '&', prep_url)
         print prep_url
         return user_token, prep_url

--- a/liclient/parsers/lixml.py
+++ b/liclient/parsers/lixml.py
@@ -21,6 +21,7 @@ class LinkedInXMLParser(object):
             'company': self.__parse_single_company,
             'location': self.__parse_company_location,
             'specialty': self.__parse_company_specialty,
+            'email-domain': self.__parse_company_email_domain,
         }
         self.tree = etree.fromstring(content)
         self.root = self.tree.tag
@@ -97,6 +98,9 @@ class LinkedInXMLParser(object):
         return LinkedInLocationParser(tree).results
 
     def __parse_company_specialty(self, tree):
+        return tree.text
+
+    def __parse_company_email_domain(self, tree):
         return tree.text
 
 class LinkedInNetworkUpdateParser(LinkedInXMLParser):

--- a/liclient/parsers/lixml.py
+++ b/liclient/parsers/lixml.py
@@ -14,7 +14,7 @@ class LinkedInXMLParser(object):
             'position': self.__parse_position,
             'skill': self.__parse_skills,
             'education': self.__parse_education,
-            'people': self.__parse_people_collection,
+            'people-search': self.__parse_people_collection,
             'twitter-account': self.__parse_twitter_accounts,
             'member-url': self.__parse_member_url_resources
         }

--- a/liclient/parsers/lixml.py
+++ b/liclient/parsers/lixml.py
@@ -18,6 +18,7 @@ class LinkedInXMLParser(object):
             'twitter-account': self.__parse_twitter_accounts,
             'member-url': self.__parse_member_url_resources,
             'companies': self.__parse_company_collection,
+            'company': self.__parse_single_company,
         }
         self.tree = etree.fromstring(content)
         self.root = self.tree.tag
@@ -84,7 +85,12 @@ class LinkedInXMLParser(object):
             rslts = LinkedInCompanyParser(c).results
             content.append(rslts)
         return content
-        
+
+    def __parse_single_company(self, tree):
+        company = tree
+        rslts = LinkedInCompanyParser(company).results
+        return [rslts]
+
 class LinkedInNetworkUpdateParser(LinkedInXMLParser):
     def __init__(self, content):
         self.xpath_collection = {

--- a/liclient/parsers/mappers.py
+++ b/liclient/parsers/mappers.py
@@ -213,6 +213,11 @@ class NetworkUpdateComment(LinkedInData):
                     'profile_url': self.profile_url}
         return jsondict
 
+class Company(LinkedInData):
+    def __init__(self, data, xml):
+        self.xml = xml
+        self.parse_data(data)
+
 class Profile(LinkedInData):
     def __init__(self, data, xml):
         self.profile_url = ''

--- a/liclient/parsers/mappers.py
+++ b/liclient/parsers/mappers.py
@@ -219,10 +219,16 @@ class Company(LinkedInData):
         self.parse_data(data)
         self.locations = []
         self.specialties = []
+        self.email_domains = []
         self.employee_count_range = ''
+        self.status = ''
+        self.company_type = ''
         self.get_locations()
         self.get_specialties()
         self.get_employee_count()
+        self.get_domains()
+        self.get_company_status()
+        self.get_company_type()
 
     def get_locations(self):
         location_xpath = etree.XPath('locations/location')
@@ -238,10 +244,29 @@ class Company(LinkedInData):
             obj = lixml.LinkedInXMLParser(etree.tostring(s)).results
             self.specialties.append(obj)
 
+    def get_domains(self):
+        domain_xpath = etree.XPath('email-domains/email-domain')
+        domains = domain_xpath(self.xml)
+        for d in domains:
+            obj = lixml.LinkedInXMLParser(etree.tostring(d)).results
+            self.email_domains.append(obj)
+
     def get_employee_count(self):
         emp_count_xpath = etree.XPath('employee-count-range/code')
         emp_count = emp_count_xpath(self.xml)
         try: self.employee_count_range = emp_count[0].text
+        except: pass
+
+    def get_company_type(self):
+        xpath = etree.XPath('company-type/code')
+        company_type = xpath(self.xml)
+        try: self.company_type = company_type[0].text
+        except: pass
+
+    def get_company_status(self):
+        xpath = etree.XPath('status/code')
+        status = xpath(self.xml)
+        try: self.status = status[0].text
         except: pass
 
 class Location(LinkedInData):

--- a/liclient/parsers/mappers.py
+++ b/liclient/parsers/mappers.py
@@ -1,23 +1,23 @@
 from lxml import etree
 import datetime, re
 import lixml
-    
+
 class LinkedInData(object):
     def __init__(self, data, xml):
         self.xml = xml
         self.parse_data(data)
-    
+
     def parse_data(self, data):
         for k in data.keys():
             self.__dict__[k] = data[k]
-            
+
     def jsonify(self):
         json = {}
         for k in self.__dict__.keys():
             if type(self.__dict__[k]) == type(''):
                 json[k] = self.__dict__[k]
         return json
-        
+
     def xmlify(self):
         converted = [re.sub('_', '-', k) for k in self.__dict__.keys()]
         for d in self.xml.iter(tag=etree.Element):
@@ -27,20 +27,20 @@ class LinkedInData(object):
                 except:
                     continue
         return etree.tostring(self.xml)
-    
+
     def __str__(self):
         return self.update_content if hasattr(self, 'update_content') and self.update_content else '<No Content>'
-    
+
 class LinkedInError(LinkedInData):
     def __repr__(self):
         return '<LinkedIn Error code %s>'.encode('utf-8') % self.status
-        
+
 class NetworkUpdate(LinkedInData):
     def __init__(self, data, xml):
         self.xml = xml
         self.update_key = None
         self.parse_data(data)
-        
+
     def jsonify(self):
         jsondict = {'first_name': self.first_name,
                     'last_name': self.last_name,
@@ -49,7 +49,7 @@ class NetworkUpdate(LinkedInData):
                     'update_key': self.update_key,
                     'profile_url': self.profile_url}
         return jsondict
-    
+
 class NetworkStatusUpdate(NetworkUpdate):
     def __init__(self, data, xml):
         self.status_xpath = etree.XPath('update-content/person/current-status')
@@ -76,12 +76,12 @@ class NetworkConnectionUpdate(NetworkUpdate):
         self.targets = []
         self.get_targets()
         self.set_update_content(self.targets)
-    
+
     def get_targets(self):
         for p in self.connection_target(self.xml):
             obj = lixml.LinkedInProfileParser(p).results
         self.targets = obj
-    
+
     def set_update_content(self, targets):
         update_str = self.first_name + ' ' + self.last_name + ' is now connected with '
         if len(targets) == 1:
@@ -99,13 +99,13 @@ class NetworkNewConnectionUpdate(NetworkConnectionUpdate):
         for p in self.connection_target(self.xml):
             obj = LinkedInProfileParser(p).results
         self.targets = obj
-    
+
     def set_update_content(self, target):
         update_str = ' is now connected with you.'
         update_str = targets[0].first_name + ' ' + targets[0].last_name + update_str
         self.update_content = update_str
         return
-    
+
 class NetworkAddressBookUpdate(NetworkNewConnectionUpdate):
     def set_update_content(self, target):
         update_str = ' just joined LinkedIn.'
@@ -124,7 +124,7 @@ class NetworkGroupUpdate(NetworkUpdate):
         self.targets = []
         self.get_targets()
         self.set_update_content(self.targets)
-    
+
     def get_targets(self):
         for g in self.group_target(self.xml):
             target_dict = {}
@@ -133,7 +133,7 @@ class NetworkGroupUpdate(NetworkUpdate):
             target_dict[k] = v
             self.targets.append(target_dict)
         return
-    
+
     def set_update_content(self, targets):
         update_str = self.first_name + ' ' + self.last_name + ' joined '
         if len(targets) == 1:
@@ -144,7 +144,7 @@ class NetworkGroupUpdate(NetworkUpdate):
         update_str = re.sub(', and $', '', update_str)
         self.update_content = update_str
         return
-    
+
 class NetworkQuestionUpdate(NetworkUpdate):
     def __init__(self, data, xml):
         self.xml = xml
@@ -152,14 +152,14 @@ class NetworkQuestionUpdate(NetworkUpdate):
         self.parse_data(data)
         self.question_title_xpath = etree.XPath('update-content/question/title')
         self.set_update_content()
-    
+
     def set_update_content(self):
         update_str = self.first_name + ' ' + self.last_name + ' asked a question: '
         qstn_text = self.question_title_xpath(self.xml)[0].text.strip()
         update_str += qstn_text
         self.update_content = update_str
         return
-    
+
 class NetworkAnswerUpdate(NetworkUpdate):
     def __init__(self, data, xml):
         self.update_key = None
@@ -169,27 +169,27 @@ class NetworkAnswerUpdate(NetworkUpdate):
         self.answer_xpath = etree.XPath('update-content/question/answers/answer')
         self.get_answers()
         self.set_update_content()
-    
+
     def get_answers(self):
         for a in self.answer_xpath(self.xml):
             self.profile_url = a.xpath('web-url')[0].text.strip()
             self.first_name = a.xpath('author/first-name')[0].text.strip()
             self.last_name = a.xpath('author/last-name')[0].text.strip()
-    
+
     def set_update_content(self):
         update_str = self.first_name + ' ' + self.last_name + ' answered: '
         qstn_text = self.question_title_xpath(self.xml)[0].text.strip()
         update_str += qstn_text
         self.update_content = update_str
         return
-    
+
 class NetworkJobPostingUpdate(NetworkUpdate):
     def __init__(self, data, xml):
         self.xml = xml
         self.parse_data(data)
         self.set_update_content()
         self.poster = lixml.LinkedInXMLParser(xml.xpath('job-poster')[0])
-    
+
     def set_update_content(self):
         update_str = self.poster.first_name + ' ' + self.poster.last_name + ' posted a job: ' + self.job_title
         self.update_content = update_str
@@ -205,7 +205,7 @@ class NetworkUpdateComment(LinkedInData):
         self.last_name = self.__content.last_name
         self.profile_url = self.__content.profile_url
         self.update_content = self.comment_xpath(xml)[0].text
-        
+
     def jsonify(self):
         jsondict = {'first_name': self.first_name,
                     'last_name': self.last_name,
@@ -214,6 +214,37 @@ class NetworkUpdateComment(LinkedInData):
         return jsondict
 
 class Company(LinkedInData):
+    def __init__(self, data, xml):
+        self.xml = xml
+        self.parse_data(data)
+        self.locations = []
+        self.specialties = []
+        self.employee_count_range = ''
+        self.get_locations()
+        self.get_specialties()
+        self.get_employee_count()
+
+    def get_locations(self):
+        location_xpath = etree.XPath('locations/location')
+        loc = location_xpath(self.xml)
+        for l in loc:
+            obj = lixml.LinkedInXMLParser(etree.tostring(l)).results
+            self.locations.append(obj)
+
+    def get_specialties(self):
+        specialty_xpath = etree.XPath('specialties/specialty')
+        specialties = specialty_xpath(self.xml)
+        for s in specialties:
+            obj = lixml.LinkedInXMLParser(etree.tostring(s)).results
+            self.specialties.append(obj)
+
+    def get_employee_count(self):
+        emp_count_xpath = etree.XPath('employee-count-range/code')
+        emp_count = emp_count_xpath(self.xml)
+        try: self.employee_count_range = emp_count[0].text
+        except: pass
+
+class Location(LinkedInData):
     def __init__(self, data, xml):
         self.xml = xml
         self.parse_data(data)
@@ -236,14 +267,14 @@ class Profile(LinkedInData):
         self.get_educations()
         self.get_twitter_accounts()
         self.get_member_url_resources()
-        
+
     def set_profile_url(self):
         try:
             profile_url_xpath = etree.XPath('site-standard-profile-request/url')
             self.profile_url = profile_url_xpath(self.xml)[0].text.strip()
         except:
             pass
-            
+
     def get_location(self):
     	try:
             location_name_xpath = etree.XPath('location/name')
@@ -252,36 +283,36 @@ class Profile(LinkedInData):
             self.country = country_code_xpath(self.xml)[0].text.strip()
         except:
             pass
-        
+
     def get_positions(self):
         profile_position_xpath = etree.XPath('positions/position')
         pos = profile_position_xpath(self.xml)
         for p in pos:
             obj = lixml.LinkedInXMLParser(etree.tostring(p)).results
             self.positions.append(obj)
-            
+
     def get_skills(self):
-        
+
         profile_skills_xpath = etree.XPath('skills/skill')
         skills = profile_skills_xpath(self.xml)
         for s in skills:
             obj = lixml.LinkedInXMLParser(etree.tostring(s)).results
             self.skills.append(obj)
-    
+
     def get_educations(self):
         profile_education_xpath = etree.XPath('educations/education')
         eds = profile_education_xpath(self.xml)
         for e in eds:
             obj = lixml.LinkedInXMLParser(etree.tostring(e)).results
             self.educations.append(obj)
-            
+
     def get_twitter_accounts(self):
     	twitter_accounts_xpath = etree.XPath('twitter-accounts/twitter-account')
     	accounts = twitter_accounts_xpath(self.xml)
     	for account in accounts:
     		obj = lixml.LinkedInXMLParser(etree.tostring(account)).results
     		self.twitter_accounts.append(obj)
-    		
+
     def get_member_url_resources(self):
     	url_resources_xpath = etree.XPath('member-url-resources/member-url')
     	urls = url_resources_xpath(self.xml)
@@ -289,19 +320,19 @@ class Profile(LinkedInData):
     		obj = lixml.LinkedInXMLParser(etree.tostring(url)).results
     		self.member_url_resources.append(obj)
 
-    		
-        
+
+
 class Position(LinkedInData):
     pass
 
 class Education(LinkedInData):
     pass
-    
+
 class TwitterAccount(LinkedInData):
     pass
-  
+
 class Skills(LinkedInData):
     pass
-    
+
 class MemberUrlResource(LinkedInData):
     pass


### PR DESCRIPTION
For the lixml.py change: the people-search response from LinkedIn is a tree with the root "people-search" instead of "people".

For the **init**.py change: the urls must not contain "~?" before the first argument.
valid url: http://api.linkedin.com/v1/people/url=http%3A%2F%2Fwww.linkedin.com%2Fin%2Fandreisoare
invalid url: http://api.linkedin.com/v1/people/~?url=http%3A%2F%2Fwww.linkedin.com%2Fin%2Fandreisoare
